### PR TITLE
Prevent painting strokes while performing pinch zoom

### DIFF
--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/lib/src/_paint_over_image.dart
+++ b/lib/src/_paint_over_image.dart
@@ -413,6 +413,7 @@ class ImagePainterState extends State<ImagePainter> {
   late final ValueNotifier<bool> _isLoaded;
   late final TextEditingController _textController;
   late final TransformationController _transformationController;
+  bool _isScaling = false;
 
   int _strokeMultiplier = 1;
   late TextDelegate textDelegate;
@@ -445,8 +446,7 @@ class ImagePainterState extends State<ImagePainter> {
 
   bool get isEdited => _controller.paintHistory.isNotEmpty;
 
-  Size get imageSize =>
-      Size(_image?.width.toDouble() ?? 0, _image?.height.toDouble() ?? 0);
+  Size get imageSize => Size(_image?.width.toDouble() ?? 0, _image?.height.toDouble() ?? 0);
 
   ///Converts the incoming image type from constructor to [ui.Image]
   Future<void> _resolveAndConvertImage() async {
@@ -512,8 +512,7 @@ class ImagePainterState extends State<ImagePainter> {
   Future<ui.Image> _loadNetworkImage(String path) async {
     final completer = Completer<ImageInfo>();
     final img = NetworkImage(path);
-    img.resolve(const ImageConfiguration()).addListener(
-        ImageStreamListener((info, _) => completer.complete(info)));
+    img.resolve(const ImageConfiguration()).addListener(ImageStreamListener((info, _) => completer.complete(info)));
     final imageInfo = await completer.future;
     _isLoaded.value = true;
     return imageInfo.image;
@@ -560,6 +559,7 @@ class ImagePainterState extends State<ImagePainter> {
                       minScale: 1,
                       panEnabled: _controller.mode == PaintMode.none,
                       scaleEnabled: widget.isScalable!,
+                      onInteractionStart: _scaleStartGesture,
                       onInteractionUpdate: _scaleUpdateGesture,
                       onInteractionEnd: _scaleEndGesture,
                       child: CustomPaint(
@@ -625,14 +625,12 @@ class ImagePainterState extends State<ImagePainter> {
               children: [
                 IconButton(
                   tooltip: textDelegate.undo,
-                  icon: widget.undoIcon ??
-                      Icon(Icons.reply, color: Colors.grey[700]),
+                  icon: widget.undoIcon ?? Icon(Icons.reply, color: Colors.grey[700]),
                   onPressed: () => _controller.undo(),
                 ),
                 IconButton(
                   tooltip: textDelegate.clearAllProgress,
-                  icon: widget.clearAllIcon ??
-                      Icon(Icons.clear, color: Colors.grey[700]),
+                  icon: widget.clearAllIcon ?? Icon(Icons.clear, color: Colors.grey[700]),
                   onPressed: () => _controller.clear(),
                 ),
               ],
@@ -642,9 +640,19 @@ class ImagePainterState extends State<ImagePainter> {
     );
   }
 
-  _scaleStartGesture(ScaleStartDetails onStart) {
-    final _zoomAdjustedOffset =
-        _transformationController.toScene(onStart.localFocalPoint);
+  void _scaleStartGesture(ScaleStartDetails onStart) {
+    final isScalingGesture = widget.isScalable == true && onStart.pointerCount > 1;
+    _isScaling = isScalingGesture;
+    if (_isScaling) {
+      _controller.setInProgress(false);
+      _controller.resetStartAndEnd();
+      if (_controller.mode == PaintMode.freeStyle) {
+        _controller.clearOffsets();
+      }
+      return;
+    }
+
+    final _zoomAdjustedOffset = _transformationController.toScene(onStart.localFocalPoint);
     if (!widget.isSignature) {
       _controller.setStart(_zoomAdjustedOffset);
       _controller.addOffsets(_zoomAdjustedOffset);
@@ -653,8 +661,22 @@ class ImagePainterState extends State<ImagePainter> {
 
   ///Fires while user is interacting with the screen to record painting.
   void _scaleUpdateGesture(ScaleUpdateDetails onUpdate) {
-    final _zoomAdjustedOffset =
-        _transformationController.toScene(onUpdate.localFocalPoint);
+    final isScalingGesture = widget.isScalable == true && onUpdate.pointerCount > 1;
+    if (isScalingGesture) {
+      if (!_isScaling) {
+        _isScaling = true;
+        _controller.setInProgress(false);
+        _controller.resetStartAndEnd();
+        if (_controller.mode == PaintMode.freeStyle) {
+          _controller.clearOffsets();
+        }
+      }
+      return;
+    } else if (_isScaling) {
+      _isScaling = false;
+    }
+
+    final _zoomAdjustedOffset = _transformationController.toScene(onUpdate.localFocalPoint);
     _controller.setInProgress(true);
     if (_controller.start == null) {
       _controller.setStart(_zoomAdjustedOffset);
@@ -664,24 +686,26 @@ class ImagePainterState extends State<ImagePainter> {
       _controller.addOffsets(_zoomAdjustedOffset);
     }
     if (_controller.onTextUpdateMode) {
-      _controller.paintHistory
-          .lastWhere((element) => element.mode == PaintMode.text)
-          .offsets = [_zoomAdjustedOffset];
+      _controller.paintHistory.lastWhere((element) => element.mode == PaintMode.text).offsets = [_zoomAdjustedOffset];
     }
   }
 
   ///Fires when user stops interacting with the screen.
   void _scaleEndGesture(ScaleEndDetails onEnd) {
     _controller.setInProgress(false);
-    if (_controller.start != null &&
-        _controller.end != null &&
-        (_controller.mode == PaintMode.freeStyle)) {
+    if (_isScaling) {
+      _isScaling = false;
+      _controller.resetStartAndEnd();
+      if (_controller.mode == PaintMode.freeStyle) {
+        _controller.clearOffsets();
+      }
+      return;
+    }
+    if (_controller.start != null && _controller.end != null && (_controller.mode == PaintMode.freeStyle)) {
       _controller.addOffsets(null);
       _addFreeStylePoints();
-      _controller.offsets.clear();
-    } else if (_controller.start != null &&
-        _controller.end != null &&
-        _controller.mode != PaintMode.text) {
+      _controller.clearOffsets();
+    } else if (_controller.start != null && _controller.end != null && _controller.mode != PaintMode.text) {
       _addEndPoints();
     }
     _controller.resetStartAndEnd();
@@ -830,9 +854,7 @@ class ImagePainterState extends State<ImagePainter> {
           AnimatedBuilder(
             animation: _controller,
             builder: (_, __) {
-              final icon = paintModes(textDelegate)
-                  .firstWhere((item) => item.mode == _controller.mode)
-                  .icon;
+              final icon = paintModes(textDelegate).firstWhere((item) => item.mode == _controller.mode).icon;
               return PopupMenuButton(
                 tooltip: textDelegate.changeMode,
                 shape: ContinuousRectangleBorder(
@@ -875,8 +897,7 @@ class ImagePainterState extends State<ImagePainter> {
             shape: ContinuousRectangleBorder(
               borderRadius: BorderRadius.circular(20),
             ),
-            icon:
-                widget.brushIcon ?? Icon(Icons.brush, color: Colors.grey[700]),
+            icon: widget.brushIcon ?? Icon(Icons.brush, color: Colors.grey[700]),
             itemBuilder: (_) => [_showRangeSlider()],
           ),
           AnimatedBuilder(
@@ -913,8 +934,7 @@ class ImagePainterState extends State<ImagePainter> {
           ),
           IconButton(
             tooltip: textDelegate.clearAllProgress,
-            icon: widget.clearAllIcon ??
-                Icon(Icons.clear, color: Colors.grey[700]),
+            icon: widget.clearAllIcon ?? Icon(Icons.clear, color: Colors.grey[700]),
             onPressed: () {
               widget.onClear?.call();
               _controller.clear();

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -52,11 +52,7 @@ class ImagePainterController extends ChangeNotifier {
 
   Offset? get end => _end;
 
-  bool get onTextUpdateMode =>
-      _mode == PaintMode.text &&
-      _paintHistory
-          .where((element) => element.mode == PaintMode.text)
-          .isNotEmpty;
+  bool get onTextUpdateMode => _mode == PaintMode.text && _paintHistory.where((element) => element.mode == PaintMode.text).isNotEmpty;
 
   ImagePainterController({
     double strokeWidth = 4.0,
@@ -165,6 +161,14 @@ class ImagePainterController extends ChangeNotifier {
     notifyListeners();
   }
 
+  void clearOffsets() {
+    if (_offsets.isEmpty) {
+      return;
+    }
+    _offsets.clear();
+    notifyListeners();
+  }
+
   bool get shouldFill {
     if (mode == PaintMode.circle || mode == PaintMode.rect) {
       return _fill;
@@ -181,28 +185,21 @@ class ImagePainterController extends ChangeNotifier {
     final painter = DrawImage(controller: this);
     final size = Size(_image!.width.toDouble(), _image!.height.toDouble());
     painter.paint(canvas, size);
-    final _convertedImage = await recorder
-        .endRecording()
-        .toImage(size.width.floor(), size.height.floor());
-    final byteData =
-        await _convertedImage.toByteData(format: ui.ImageByteFormat.png);
+    final _convertedImage = await recorder.endRecording().toImage(size.width.floor(), size.height.floor());
+    final byteData = await _convertedImage.toByteData(format: ui.ImageByteFormat.png);
     return byteData?.buffer.asUint8List();
   }
 
   Future<Uint8List?> _renderSignature() async {
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
-    SignaturePainter painter =
-        SignaturePainter(controller: this, backgroundColor: Colors.blue);
+    SignaturePainter painter = SignaturePainter(controller: this, backgroundColor: Colors.blue);
 
     Size size = Size(_rect.width, _rect.height);
 
     painter.paint(canvas, size);
-    final _convertedImage = await recorder
-        .endRecording()
-        .toImage(size.width.floor(), size.height.floor());
-    final byteData =
-        await _convertedImage.toByteData(format: ui.ImageByteFormat.png);
+    final _convertedImage = await recorder.endRecording().toImage(size.width.floor(), size.height.floor());
+    final byteData = await _convertedImage.toByteData(format: ui.ImageByteFormat.png);
     return byteData?.buffer.asUint8List();
   }
 


### PR DESCRIPTION
- treat multi-touch interactions as scaling-only and bypass paint updates
- reset ongoing stroke state when zoom gestures begin or end
- add ImagePainterController.clearOffsets() so freestyle buffers can be cleared safely